### PR TITLE
Add standardized issue templates

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+1. <!-- First step -->
+2. <!-- Second step -->
+3. <!-- And so on... -->
+
+## Expected Behavior
+<!-- A clear and concise description of what you expected to happen -->
+
+## Actual Behavior
+<!-- A clear and concise description of what actually happened -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+- OS: <!-- e.g. Ubuntu 22.04, Windows 11, macOS 13.0 -->
+- Browser/Application: <!-- e.g. Chrome 112, Firefox 111, VS Code 1.77 -->
+- Version: <!-- e.g. v1.2.3 -->
+
+## Additional Context
+<!-- Add any other context about the problem here -->
+
+## Possible Solution
+<!-- If you have ideas on how to fix the issue, please describe them here -->
+
+## Branch Naming
+<!-- When fixing this bug, please use the following branch naming convention -->
+`fix/issue-number-short-description` (e.g., `fix/123-login-error`)

--- a/ISSUE_TEMPLATE/code_refactoring.md
+++ b/ISSUE_TEMPLATE/code_refactoring.md
@@ -1,0 +1,29 @@
+---
+name: Code Refactoring
+about: Suggest code improvements without changing functionality
+title: '[REFACTOR] '
+labels: refactoring
+assignees: ''
+---
+
+## Component to Refactor
+<!-- Which component, module, or code section needs refactoring? -->
+
+## Current Issues
+<!-- What problems exist in the current implementation? -->
+
+## Proposed Changes
+<!-- How do you suggest refactoring this code? -->
+
+## Benefits
+<!-- What benefits will this refactoring bring? (e.g., improved readability, performance, maintainability) -->
+
+## Potential Risks
+<!-- Are there any risks or potential side effects of this refactoring? -->
+
+## Testing Strategy
+<!-- How can we ensure the refactoring doesn't break existing functionality? -->
+
+## Branch Naming
+<!-- When refactoring code, please use the following branch naming convention -->
+`refactor/component-name`

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Rivendell Tech Support
+    url: mailto:hello@rivendell.trading
+    about: Please contact us directly for urgent issues or private concerns.
+  - name: Rivendell Tech LinkedIn
+    url: https://www.linkedin.com/company/rivendell-tech
+    about: Follow us on LinkedIn for updates and announcements.

--- a/ISSUE_TEMPLATE/dependency_update.md
+++ b/ISSUE_TEMPLATE/dependency_update.md
@@ -1,0 +1,29 @@
+---
+name: Dependency Update
+about: Update dependencies or components
+title: '[UPDATE] '
+labels: dependencies
+assignees: ''
+---
+
+## Component to Update
+<!-- Which dependency or component needs to be updated? -->
+
+## Current Version
+<!-- What is the current version? -->
+
+## Target Version
+<!-- What version should it be updated to? -->
+
+## Reason for Update
+<!-- Why does this dependency need to be updated? (e.g., security fixes, new features, etc.) -->
+
+## Potential Impact
+<!-- How might this update affect the project? Are there breaking changes? -->
+
+## Testing Plan
+<!-- How should this update be tested? -->
+
+## Branch Naming
+<!-- When updating dependencies, please use the following branch naming convention -->
+`update/component-name`

--- a/ISSUE_TEMPLATE/documentation_update.md
+++ b/ISSUE_TEMPLATE/documentation_update.md
@@ -1,0 +1,23 @@
+---
+name: Documentation Update
+about: Suggest improvements or report issues with documentation
+title: '[DOCS] '
+labels: documentation
+assignees: ''
+---
+
+## Documentation Issue
+<!-- Describe what's missing, unclear, or incorrect in the documentation -->
+
+## Affected Documentation
+<!-- Which documentation pages or sections need to be updated? -->
+
+## Suggested Changes
+<!-- Describe what changes you think should be made to the documentation -->
+
+## Additional Information
+<!-- Any additional information, context, or references that might help -->
+
+## Branch Naming
+<!-- When updating documentation, please use the following branch naming convention -->
+`docs/documentation-update`

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature Request
+about: Suggest a new feature for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+<!-- A clear and concise description of the feature you're requesting -->
+
+## Problem Statement
+<!-- Describe the problem this feature would solve -->
+
+## Proposed Solution
+<!-- Describe how you envision this feature working -->
+
+## Alternatives Considered
+<!-- Describe any alternative solutions or features you've considered -->
+
+## Additional Context
+<!-- Add any other context, screenshots, or examples about the feature request here -->
+
+## Implementation Notes
+<!-- Any ideas on how this might be implemented (optional) -->
+
+## Branch Naming
+<!-- When implementing this feature, please use the following branch naming convention -->
+`feat/short-description`

--- a/ISSUE_TEMPLATE/test_case.md
+++ b/ISSUE_TEMPLATE/test_case.md
@@ -1,0 +1,29 @@
+---
+name: Test Case
+about: Add new test cases or improve existing ones
+title: '[TEST] '
+labels: testing
+assignees: ''
+---
+
+## Test Description
+<!-- Describe what functionality needs to be tested -->
+
+## Test Scope
+<!-- What components, features, or functionality should this test cover? -->
+
+## Test Type
+<!-- What type of test is needed? (e.g., unit test, integration test, end-to-end test) -->
+
+## Test Scenarios
+<!-- List the specific scenarios that should be tested -->
+
+## Expected Results
+<!-- What are the expected outcomes of these tests? -->
+
+## Additional Context
+<!-- Any additional information that might help with implementing these tests -->
+
+## Branch Naming
+<!-- When adding test cases, please use the following branch naming convention -->
+`test/test-case-name`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Community health files for [@Rivendell Tech](https://github.com/rivendell-tech) organization.
 
+## Issue Templates
+
+The repository includes the following issue templates to standardize issue reporting:
+
+- **Bug Report**: For reporting bugs and unexpected behavior
+- **Feature Request**: For suggesting new features or enhancements
+- **Documentation Update**: For suggesting improvements to documentation
+- **Code Refactoring**: For proposing code structure improvements
+- **Dependency Update**: For updating project dependencies
+- **Test Case**: For adding or updating test cases
+
 ## Contact
 
 [LinkedIn](https://www.linkedin.com/company/rivendell-tech) | [Email](mailto:hello@rivendell.trading)


### PR DESCRIPTION
This PR adds standardized issue templates to improve consistency and completeness of issue reporting across the organization.

## Templates Added
- Bug report template
- Feature request template
- Documentation improvement template

## Implementation Details
- Templates are placed in the `.github/ISSUE_TEMPLATE` directory
- Each template uses GitHub's issue template format
- Templates include appropriate labels and assignee suggestions

Closes rivendell-tech/organization-workflow#1